### PR TITLE
Migrate away from MacOS 13 runner

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -117,7 +117,7 @@ jobs:
 
   macos:
     name: Build & test on MacOS
-    runs-on: macos-14-large
+    runs-on: macos-15-intel
     strategy:
       matrix:
         # If this workflow is called to build for release, build for x64 and ARM64

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -117,7 +117,7 @@ jobs:
 
   macos:
     name: Build & test on MacOS
-    runs-on: macos-14
+    runs-on: macos-14-large
     strategy:
       matrix:
         # If this workflow is called to build for release, build for x64 and ARM64

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -117,7 +117,7 @@ jobs:
 
   macos:
     name: Build & test on MacOS
-    runs-on: macos-13
+    runs-on: macos-14
     strategy:
       matrix:
         # If this workflow is called to build for release, build for x64 and ARM64


### PR DESCRIPTION
The `macos-13` image will be unavailable from December 4th. This PR migrates the `build & test` workflow for macOS to the `macos-15-intel` image.