### PR TITLE
Fix lint workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,6 +14,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
-      - uses: Klavionik/pre-commit-action@main
+      - uses: pre-commit/action@v3.0.1
         with:
           extra_args: "--all-files --hook-stage manual"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,4 +16,4 @@ jobs:
       - uses: actions/setup-python@v5
       - uses: Klavionik/pre-commit-action@main
         with:
-          extra_args: "--hook-stage manual"
+          extra_args: "--all-files --hook-stage manual"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ profile = "black"
 
 [tool.vulture]
 paths = ["python", "tests"]
-ignore_names = ["read_*", "write_*"]
+min_confidence = 100
 
 [tool.maturin]
 python-source = "python"


### PR DESCRIPTION
Turns out, the lint workflow doesn't perform any checks right now due to the current value of `extra_args` overwriting the default `--all-files`. Silly me.